### PR TITLE
Allow instalation on PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "php": "^7.1",
+    "php": "^7.1 || ^8.0",
     "php-http/httplug": "^1.0 || ^2.0",
     "php-http/message": "^1.0",
     "php-http/client-common": "^1.0 || ^2.0",


### PR DESCRIPTION
The library works fine in php 8. To work properly in php 8 needs to allow installation for composer.